### PR TITLE
✨ Add support for prefers-reduced-motion

### DIFF
--- a/packages/ui/src/modules/app/components/App/Providers/GlobalStyles/index.js
+++ b/packages/ui/src/modules/app/components/App/Providers/GlobalStyles/index.js
@@ -17,6 +17,14 @@ const Container = createGlobalStyle`
   ${modalityStyles}
   ${elementStyles}
   ${typographyStyles}
+ 
+  @media screen and (prefers-reduced-motion: reduce), (update: slow) {
+    * {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+    }
+  }
 `;
 
 const GlobalStyle = () => <Container />;


### PR DESCRIPTION
Notice the page header snapping after `[✔️] Reduce motion` is enabled 

---
![prefers-reduced](https://user-images.githubusercontent.com/2074517/70367377-5680b980-186d-11ea-9bf7-db929a85ed92.gif)

Closes #32 
