### PR TITLE
feat(ui): ✨ Add user management page and respective nav links

### DIFF
--- a/packages/common/src/types/permission/index.js
+++ b/packages/common/src/types/permission/index.js
@@ -1,9 +1,10 @@
 import { hasPermission } from './selectors';
-import { Enumeration } from './typedef';
+import { Enumeration, values } from './typedef';
 
 const Permission = {
   ...Enumeration,
   hasPermission,
+  values,
 };
 
 export { Permission };

--- a/packages/common/src/types/permission/typedef.js
+++ b/packages/common/src/types/permission/typedef.js
@@ -1,3 +1,4 @@
+import { values as ramdaValues } from 'ramda';
 import { UserRole } from 'types/userRole';
 
 const { ADMIN } = UserRole;
@@ -10,4 +11,6 @@ const Access = {
   USERS_MANAGE: [ADMIN],
 };
 
-export { Access, Enumeration };
+const values = ramdaValues(Enumeration);
+
+export { Access, Enumeration, values };

--- a/packages/common/src/types/userRole/index.js
+++ b/packages/common/src/types/userRole/index.js
@@ -1,7 +1,8 @@
-import { Enumeration } from './typedef';
+import { Enumeration, values } from './typedef';
 
 const UserRole = {
   ...Enumeration,
+  values,
 };
 
 export { UserRole };

--- a/packages/common/src/types/userRole/typedef.js
+++ b/packages/common/src/types/userRole/typedef.js
@@ -1,6 +1,10 @@
+import { values as ramdaValues } from 'ramda';
+
 const Enumeration = {
   ADMIN: 'ADMIN',
   USER: 'USER',
 };
 
-export { Enumeration };
+const values = ramdaValues(Enumeration);
+
+export { Enumeration, values };

--- a/packages/ui/craco.config.js
+++ b/packages/ui/craco.config.js
@@ -6,7 +6,7 @@ module.exports = {
     plugins: [
       'add-react-displayname',
       ['babel-plugin-styled-components', { ssr: false }],
-      ...whenDev(() => ['react-refresh/babel'], []),
+      ...whenDev(() => [['react-refresh/babel', { skipEnvCheck: true }]], []),
       ...whenProd(() => ['babel-plugin-jsx-remove-data-test-id'], []),
     ],
   },
@@ -48,7 +48,7 @@ module.exports = {
       },
       plugins: [
         ...(webpackConfig.plugins || []),
-        ...whenDev(() => [new ReactRefreshPlugin()], []),
+        ...whenDev(() => [new ReactRefreshPlugin({ overlay: false })], []),
       ],
     }),
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
     "start:pre": "(cat ../../.ini/certs/cert.pem ../../.ini/certs/key.pem > ../../node_modules/webpack-dev-server/ssl/server.pem) || :",
     "start:prod": "yarn run -s serve -l 3000 --ssl-cert ../../.ini/certs/cert.pem --ssl-key ../../.ini/certs/key.pem",
     "start:prod:heroku": "yarn run -s serve",
-    "test": "craco test --passWithNoTests",
+    "test": "NODE_ENV=test craco test --passWithNoTests",
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=../../.tmp/test-results/jest/ui yarn -s test --ci --runInBand --reporters=default --reporters=jest-junit",
     "test:watch": "craco test --passWithNoTests --color"
   },

--- a/packages/ui/src/i18n/en/app.js
+++ b/packages/ui/src/i18n/en/app.js
@@ -12,6 +12,7 @@ export const app = {
       registration: 'Sign Up',
       root: 'Home',
       testPage: 'Test Page',
+      userManagement: 'Users',
     },
     openNavigation: 'Open navigation',
     tapHereOrSwipeToClose: 'Tap here or swipe to close',

--- a/packages/ui/src/i18n/en/users.js
+++ b/packages/ui/src/i18n/en/users.js
@@ -1,0 +1,3 @@
+export const users = {
+  users: 'Users',
+};

--- a/packages/ui/src/modules/app/components/App/Layout/Header/UserMenu/Navigation/index.spec.js
+++ b/packages/ui/src/modules/app/components/App/Layout/Header/UserMenu/Navigation/index.spec.js
@@ -1,5 +1,8 @@
+import { UserRole, Permission } from '@boilerplate-monorepo/common';
 import React from 'react';
+import * as UseAuthHook from 'shared/useAuth';
 import { render } from 'testHelpers';
+import { Route } from 'types/route';
 import { Navigation } from '.';
 
 jest.mock('shared/Button');
@@ -19,5 +22,111 @@ describe('<Navigation/>', () => {
     const { container } = renderComponent();
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  const authRouteName = 'AUTH_ROUTE_NAME';
+  const isAuthenticationRequired = true;
+  const role = UserRole.USER;
+
+  const navRoutes = [
+    Route.example({ isAuthenticationRequired, name: authRouteName }),
+  ];
+
+  describe('when user is authenticated', () => {
+    const isAuthenticated = true;
+
+    let useAuth = null;
+
+    beforeEach(() => {
+      useAuth = td.replace(UseAuthHook, 'useAuth');
+
+      td.when(useAuth()).thenReturn({ isAuthenticated, role });
+      td.replace(Route, 'values', navRoutes);
+    });
+
+    test('renders the user account link', () => {
+      const { getByTestId } = renderComponent();
+
+      expect(getByTestId(Route.USER_ACCOUNT.name)).not.toBeNull();
+    });
+
+    describe('and the nav link requires permission', () => {
+      const permissionRouteName = 'PERMISSION_ROUTE_NAME';
+
+      const permissionRoutes = [
+        Route.example({
+          isAuthenticationRequired,
+          name: permissionRouteName,
+          requiredPermission: Permission.USERS_MANAGE,
+        }),
+      ];
+
+      beforeEach(() => {
+        td.replace(Route, 'values', permissionRoutes);
+      });
+
+      describe('and user has permission', () => {
+        const adminRole = UserRole.ADMIN;
+
+        beforeEach(() => {
+          td.when(useAuth()).thenReturn({ isAuthenticated, role: adminRole });
+        });
+
+        test('renders the permission nav link', () => {
+          const { getByTestId } = renderComponent();
+
+          expect(getByTestId(permissionRouteName)).not.toBeNull();
+        });
+      });
+
+      describe('and user DOES NOT have permission', () => {
+        beforeEach(() => {
+          td.when(useAuth()).thenReturn({ isAuthenticated, role });
+        });
+
+        test('does not renders the permission nav link', () => {
+          const { queryByTestId } = renderComponent();
+
+          expect(queryByTestId(permissionRouteName)).toBeNull();
+        });
+      });
+    });
+
+    describe('and the nav link DOES NOT require permission', () => {
+      test('renders the authenticated nav link', () => {
+        td.when(useAuth()).thenReturn({ isAuthenticated, role });
+
+        const { getByTestId } = renderComponent();
+
+        expect(getByTestId(authRouteName)).not.toBeNull();
+      });
+    });
+  });
+
+  describe('when user is NOT authenticated', () => {
+    const isAuthenticated = false;
+
+    let useAuth = null;
+
+    beforeEach(() => {
+      useAuth = td.replace(UseAuthHook, 'useAuth');
+
+      td.when(useAuth()).thenReturn({ isAuthenticated, role: null });
+      td.replace(Route, 'values', navRoutes);
+    });
+
+    test('DOES NOT render the user account link', () => {
+      const { queryByTestId } = renderComponent();
+
+      expect(queryByTestId(Route.USER_ACCOUNT.name)).toBeNull();
+    });
+
+    test('does not render the authenticated nav link', () => {
+      td.when(useAuth()).thenReturn({ isAuthenticated, role });
+
+      const { queryByTestId } = renderComponent();
+
+      expect(queryByTestId(authRouteName)).toBeNull();
+    });
   });
 });

--- a/packages/ui/src/modules/app/components/App/Layout/Navigation/__snapshots__/index.spec.js.snap
+++ b/packages/ui/src/modules/app/components/App/Layout/Navigation/__snapshots__/index.spec.js.snap
@@ -9,10 +9,16 @@ exports[`<Navigation/> renders properly 1`] = `
     class="Navigation__NavLinks-hlefot-1 blIUvd"
   >
     <x-navlink
+      data-testid="dashboard"
       id="navigation"
       route="[object Object]"
     />
     <x-navlink
+      data-testid="about"
+      route="[object Object]"
+    />
+    <x-navlink
+      data-testid="userManagement"
       route="[object Object]"
     />
   </div>

--- a/packages/ui/src/modules/app/components/App/Layout/Navigation/index.spec.js
+++ b/packages/ui/src/modules/app/components/App/Layout/Navigation/index.spec.js
@@ -1,5 +1,9 @@
+import { UserRole, Permission } from '@boilerplate-monorepo/common';
 import React from 'react';
+import * as UseAuthHook from 'shared/useAuth';
 import { render } from 'testHelpers';
+import { Route } from 'types/route';
+import * as NavRoutes from '../../../../routes';
 import { Navigation } from '.';
 
 jest.mock('shared/useAuth');
@@ -20,5 +24,97 @@ describe('<Navigation/>', () => {
     const { container } = renderComponent();
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  const authRouteName = 'AUTH_ROUTE_NAME';
+  const isAuthenticationRequired = true;
+  const role = UserRole.USER;
+
+  const navRoutes = [
+    Route.example({ isAuthenticationRequired, name: authRouteName }),
+  ];
+
+  describe('when user is authenticated', () => {
+    const isAuthenticated = true;
+
+    let useAuth = null;
+
+    beforeEach(() => {
+      useAuth = td.replace(UseAuthHook, 'useAuth');
+
+      td.replace(NavRoutes, 'navRoutes', navRoutes);
+    });
+
+    describe('and the nav link requires permission', () => {
+      const permissionRouteName = 'PERMISSION_ROUTE_NAME';
+
+      const permissionRoutes = [
+        Route.example({
+          isAuthenticationRequired,
+          name: permissionRouteName,
+          requiredPermission: Permission.USERS_MANAGE,
+        }),
+      ];
+
+      beforeEach(() => {
+        td.replace(NavRoutes, 'navRoutes', permissionRoutes);
+      });
+
+      describe('and user has permission', () => {
+        const adminRole = UserRole.ADMIN;
+
+        beforeEach(() => {
+          td.when(useAuth()).thenReturn({ isAuthenticated, role: adminRole });
+        });
+
+        test('renders the permission nav link', () => {
+          const { getByTestId } = renderComponent();
+
+          expect(getByTestId(permissionRouteName)).not.toBeNull();
+        });
+      });
+
+      describe('and user DOES NOT have permission', () => {
+        beforeEach(() => {
+          td.when(useAuth()).thenReturn({ isAuthenticated, role });
+        });
+
+        test('does not renders the permission nav link', () => {
+          const { queryByTestId } = renderComponent();
+
+          expect(queryByTestId(permissionRouteName)).toBeNull();
+        });
+      });
+    });
+
+    describe('and the nav link DOES NOT require permission', () => {
+      test('renders the authenticated nav link', () => {
+        td.when(useAuth()).thenReturn({ isAuthenticated, role });
+
+        const { getByTestId } = renderComponent();
+
+        expect(getByTestId(authRouteName)).not.toBeNull();
+      });
+    });
+  });
+
+  describe('when user is NOT authenticated', () => {
+    const isAuthenticated = false;
+
+    let useAuth = null;
+
+    beforeEach(() => {
+      useAuth = td.replace(UseAuthHook, 'useAuth');
+
+      td.replace(NavRoutes, 'navRoutes', navRoutes);
+    });
+
+    test('does not render the authenticated nav link', () => {
+      td.when(useAuth()).thenReturn({ isAuthenticated, role });
+
+      const { queryByTestId } = renderComponent();
+
+      expect(queryByTestId(authRouteName)).toBeNull();
+    });
   });
 });

--- a/packages/ui/src/modules/app/components/App/Providers/Auth/index.js
+++ b/packages/ui/src/modules/app/components/App/Providers/Auth/index.js
@@ -4,6 +4,7 @@ import { node } from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { useUserLogout } from 'shared/graphql';
 import { AccessToken } from 'types/accessToken';
+import { Jwt } from 'types/jwt';
 import { Provider } from 'types/provider';
 
 const Auth = ({ children }) => {
@@ -12,7 +13,7 @@ const Auth = ({ children }) => {
   );
 
   const client = useApolloClient();
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(Jwt.decode(AccessToken.read()));
   const [mutate] = useUserLogout();
 
   const logout = useCallback(async () => {

--- a/packages/ui/src/modules/app/routes/index.js
+++ b/packages/ui/src/modules/app/routes/index.js
@@ -8,6 +8,7 @@ import { NotFound } from 'modules/notFound';
 import { Signup } from 'modules/signup';
 import { TestPage } from 'modules/testPage';
 import { User } from 'modules/user';
+import { Users } from 'modules/users';
 
 const componentMap = {
   about: About,
@@ -19,10 +20,11 @@ const componentMap = {
   root: Dashboard,
   signup: Signup,
   testPage: TestPage,
+  userManagement: Users,
 };
 
 const addComponent = (route) => {
-  const component = defaultTo(Dashboard, componentMap[route.name]);
+  const component = defaultTo(NotFound, componentMap[route.name]);
 
   return mergeRight(route, { component });
 };

--- a/packages/ui/src/modules/logout/components/index.js
+++ b/packages/ui/src/modules/logout/components/index.js
@@ -7,9 +7,10 @@ const Logout = () => {
   const history = useHistory();
   const { logout } = useAuth();
 
-  useTimeout(() => history.push(Route.LOGIN.path), 1);
-
-  logout();
+  useTimeout(() => {
+    logout();
+    history.push(Route.LOGIN.path);
+  }, 1);
 
   return null;
 };

--- a/packages/ui/src/modules/user/components/Routing/__snapshots__/index.spec.js.snap
+++ b/packages/ui/src/modules/user/components/Routing/__snapshots__/index.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Routing/> renders properly 1`] = `
+<x-switch>
+  <x-route
+    path="/account/recovery"
+  />
+  <x-authroute />
+</x-switch>
+`;

--- a/packages/ui/src/modules/user/components/Routing/index.spec.js
+++ b/packages/ui/src/modules/user/components/Routing/index.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'testHelpers';
+import { Routing } from '.';
+
+jest.mock('shared/AuthRoute');
+
+describe('<Routing/>', () => {
+  const defaultProps = {};
+
+  const renderComponent = (overrides) =>
+    render(<Routing {...defaultProps} {...overrides} />);
+
+  test('renders properly', () => {
+    const { container } = renderComponent();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/modules/users/components/List/__snapshots__/index.spec.js.snap
+++ b/packages/ui/src/modules/users/components/List/__snapshots__/index.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<List/> renders properly 1`] = `
+<x-breadcrumbs>
+  <x-breadcrumb
+    isend="true"
+    text="t(users)"
+    to="/users"
+  />
+</x-breadcrumbs>
+`;

--- a/packages/ui/src/modules/users/components/List/index.js
+++ b/packages/ui/src/modules/users/components/List/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Body, Breadcrumb, Breadcrumbs, Header } from 'shared/Content';
+import { useTranslate } from 'shared/useTranslate';
+import { Route } from 'types/route';
+
+const List = () => {
+  const t = useTranslate({
+    component: 'list',
+    namespace: 'users',
+  });
+
+  return (
+    <>
+      <Breadcrumbs>
+        <Breadcrumb isEnd text={t('users')} to={Route.USER_MANAGEMENT.path} />
+      </Breadcrumbs>
+      <Header title={t('users')} />
+      <Body>
+        <p>coming soon...</p>
+      </Body>
+    </>
+  );
+};
+
+export { List };

--- a/packages/ui/src/modules/users/components/List/index.spec.js
+++ b/packages/ui/src/modules/users/components/List/index.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'testHelpers';
+import { List } from '.';
+
+jest.mock('shared/Content');
+
+describe('<List/>', () => {
+  const defaultProps = {};
+
+  const renderComponent = (overrides) =>
+    render(<List {...defaultProps} {...overrides} />);
+
+  test('renders properly', () => {
+    const { container } = renderComponent();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/modules/users/components/Routing/__snapshots__/index.spec.js.snap
+++ b/packages/ui/src/modules/users/components/Routing/__snapshots__/index.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Routing/> renders properly 1`] = `
+<x-switch>
+  <x-authroute />
+</x-switch>
+`;

--- a/packages/ui/src/modules/users/components/Routing/index.js
+++ b/packages/ui/src/modules/users/components/Routing/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Switch } from 'react-router-dom';
+import { AuthRoute } from 'shared/AuthRoute';
+import { List } from '../List';
+
+const Routing = () => (
+  <Switch>
+    <AuthRoute component={List} />
+  </Switch>
+);
+
+export { Routing };

--- a/packages/ui/src/modules/users/components/Routing/index.spec.js
+++ b/packages/ui/src/modules/users/components/Routing/index.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'testHelpers';
+import { Routing } from '.';
+
+jest.mock('shared/AuthRoute');
+
+describe('<Routing/>', () => {
+  const defaultProps = {};
+
+  const renderComponent = (overrides) =>
+    render(<Routing {...defaultProps} {...overrides} />);
+
+  test('renders properly', () => {
+    const { container } = renderComponent();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/modules/users/components/index.js
+++ b/packages/ui/src/modules/users/components/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Content } from 'shared/Content';
+import { Page } from 'shared/Page';
+import { Routing } from './Routing';
+
+const Users = () => (
+  <Page>
+    <Content>
+      <Routing />
+    </Content>
+  </Page>
+);
+
+export { Users };

--- a/packages/ui/src/modules/users/index.js
+++ b/packages/ui/src/modules/users/index.js
@@ -1,0 +1,11 @@
+import { Utils } from '@boilerplate-monorepo/common';
+import { lazy } from 'react';
+
+const Lazy = lazy(() =>
+  import(
+    /* webpackChunkName: "users" */
+    './components'
+  ).then(Utils.renameKeys({ Users: 'default' }))
+);
+
+export { Lazy as Users };

--- a/packages/ui/src/shared/AuthRoute/__mocks__/index.js
+++ b/packages/ui/src/shared/AuthRoute/__mocks__/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const AuthRoute = (props) => <x-AuthRoute {...props} />;
+
+export { AuthRoute };

--- a/packages/ui/src/shared/Can/index.js
+++ b/packages/ui/src/shared/Can/index.js
@@ -1,0 +1,15 @@
+import { Permission, UserRole } from '@boilerplate-monorepo/common';
+import { oneOf } from 'prop-types';
+
+const Can = ({ children, permission, role }) => {
+  if (!Permission.hasPermission(role, permission)) return null;
+
+  return children;
+};
+
+Can.propTypes = {
+  permission: oneOf(Permission.values).isRequired,
+  role: oneOf(UserRole.values).isRequired,
+};
+
+export { Can };

--- a/packages/ui/src/shared/Can/index.spec.js
+++ b/packages/ui/src/shared/Can/index.spec.js
@@ -1,0 +1,47 @@
+import { Permission, UserRole } from '@boilerplate-monorepo/common';
+import React from 'react';
+import { render } from 'testHelpers';
+import { Can } from '.';
+
+describe('<Can/>', () => {
+  const permission = Permission.USERS_MANAGE;
+  const role = UserRole.ADMIN;
+
+  const defaultProps = {
+    permission,
+    role,
+  };
+
+  const renderComponent = (overrides) =>
+    render(<Can {...defaultProps} {...overrides} />);
+
+  describe('when a role has a permission', () => {
+    beforeEach(() => {
+      const hasPermission = td.replace(Permission, 'hasPermission');
+
+      td.when(hasPermission(role, permission)).thenReturn(true);
+    });
+
+    test('renders children', () => {
+      const children = <x-child data-testid="child" />;
+      const { getByTestId } = renderComponent({ children });
+
+      expect(getByTestId('child')).not.toBeNull();
+    });
+  });
+
+  describe('when a role DOES NOT have permission', () => {
+    beforeEach(() => {
+      const hasPermission = td.replace(Permission, 'hasPermission');
+
+      td.when(hasPermission(role, permission)).thenReturn(false);
+    });
+
+    test('renders nothing', () => {
+      const children = <x-child data-testid="child" />;
+      const { queryByTestId } = renderComponent({ children });
+
+      expect(queryByTestId('child')).toBeNull();
+    });
+  });
+});

--- a/packages/ui/src/types/jwt/selectors.js
+++ b/packages/ui/src/types/jwt/selectors.js
@@ -1,5 +1,12 @@
 import jwtDecode from 'jwt-decode';
 
-const decode = (token) => jwtDecode(token);
+const decode = (token) => {
+  try {
+    return jwtDecode(token);
+  } catch (error) {
+    // Do nothing
+    return null;
+  }
+};
 
 export { decode };

--- a/packages/ui/src/types/route/examples.js
+++ b/packages/ui/src/types/route/examples.js
@@ -5,8 +5,10 @@ const example = (overrides) => ({
   [SORT_PROP_NAME]: 1,
   exact: true,
   icon: MdDashboard,
+  isAuthenticationRequired: false,
   name: 'dashboard',
   path: '/',
+  requiredPermission: null,
   ...overrides,
 });
 

--- a/packages/ui/src/types/route/typedef.js
+++ b/packages/ui/src/types/route/typedef.js
@@ -1,3 +1,4 @@
+import { Permission } from '@boilerplate-monorepo/common';
 import { config } from 'config';
 import { shape, string } from 'prop-types';
 import { values as ramdaValues } from 'ramda';
@@ -7,6 +8,7 @@ import {
   FaSignInAlt,
   FaSignOutAlt,
   FaUserAlt,
+  FaUsersCog,
 } from 'react-icons/fa';
 import { GiFireBowl } from 'react-icons/gi';
 import { MdDashboard, MdPersonAdd } from 'react-icons/md';
@@ -65,6 +67,7 @@ export const Enumeration = {
   },
   USER_ACCOUNT: {
     icon: FaUserAlt,
+    isAuthenticationRequired: true,
     name: 'account',
     path: '/account',
   },
@@ -112,6 +115,15 @@ export const Enumeration = {
     icon: FaUserAlt,
     name: 'accountSecurity',
     path: '/account/security',
+  },
+  USER_MANAGEMENT: {
+    [SORT_PROP_NAME]: 20,
+    exact,
+    icon: FaUsersCog,
+    isAuthenticationRequired: true,
+    name: 'userManagement',
+    path: '/users',
+    requiredPermission: Permission.USERS_MANAGE,
   },
 };
 


### PR DESCRIPTION
- ✨ Add `Can` shared component to restrict by permission
- 🐛 Set initial user context from jwt if available
- 🐛 Fix how react-refresh is ran during tests
- 🐛 Fix write state warning on logout
- ✨ Add user management link in side nav and placeholder page
- ✨ Add user management link to mobile hamburger menu
